### PR TITLE
Read email and username from UserInfo response

### DIFF
--- a/commons/src/main/java/com/pawelniewiadomski/jira/openid/authentication/providers/DiscoverablyOauth2ProviderType.java
+++ b/commons/src/main/java/com/pawelniewiadomski/jira/openid/authentication/providers/DiscoverablyOauth2ProviderType.java
@@ -199,9 +199,8 @@ public class DiscoverablyOauth2ProviderType extends AbstractProviderType impleme
                     .buildHeaderMessage();
 
             final OAuthResourceResponse userInfoResponse = oAuthClient.resource(bearerClientRequest, OAuth.HttpMethod.GET, OAuthResourceResponse.class);
-            final Map<String, Object> userInfo = JSONUtils.parseJSON(payload);
-
             payload = userInfoResponse.getBody();
+            final Map<String, Object> userInfo = JSONUtils.parseJSON(payload);
 
             // as a last resort try upn from user info (in case of Azure that's email)
             email = defaultIfEmpty(email, (String) userInfo.get("email"));


### PR DESCRIPTION
If the UserInfo request is send to the provider we have to read the email and username from the UserInfo response payload (Json)